### PR TITLE
adding dex files to the file list

### DIFF
--- a/coeus-python/coeus_python.pyi
+++ b/coeus-python/coeus_python.pyi
@@ -58,6 +58,11 @@ class VmResult:
         """Cast the VmResult to a python native type"""
 class DexClassObject:
     pass
+class Dex:
+    def get_name(self) -> str:
+        """Get name of the Dexfile"""
+    def get_identifier(self) -> str:
+        """Get identifier of Dexfile"""
 class DexString:
     def content(self) -> str:
         """Return the content of this String"""

--- a/coeus/coeus_parse/src/extraction.rs
+++ b/coeus/coeus_parse/src/extraction.rs
@@ -53,8 +53,11 @@ pub fn extract_single_threaded(
 
         if check_for_dex_signature(ptr) {
             let array_view = ArrayView::new(zip_bytes.as_slice());
-
             dex_files.extend(found_dex(&file_name, &array_view, should_build_graph));
+            other_files.insert(
+                file.name().to_string(),
+                Arc::new(BinaryObject::new(zip_bytes)),
+            );
         } else if (max_depth == 0 || depth <= max_depth) && check_for_zip_signature(ptr) {
             let zip_bytes = zip_bytes;
             let array_view = ArrayView::new(zip_bytes.as_slice());
@@ -150,10 +153,15 @@ pub fn extract_zip(
         }
 
         if check_for_dex_signature(ptr) {
+            let dex_bytes = zip_bytes.clone();
             dex_jobs.push(std::thread::spawn(move || {
                 let array_view = ArrayView::new(zip_bytes.as_slice());
                 found_dex(&file_name, &array_view, should_build_graph)
             }));
+            other_files.insert(
+                file.name().to_string(),
+                Arc::new(BinaryObject::new(dex_bytes)),
+            );
         } else if (max_depth == 0 || depth <= max_depth) && check_for_zip_signature(ptr) {
             let zip_bytes = zip_bytes;
             let array_view = ArrayView::new(zip_bytes.as_slice());


### PR DESCRIPTION
By adding the dex files to the file list we have a simple way to get the bytes of the dex files. 
Just use:
`ao.get_file('classes.dex')` 

Maybe it's also possible to extend the `multidex` structure, but this could be a little bit cumbersome.